### PR TITLE
Fix new course GHA trigger (try to)

### DIFF
--- a/.github/workflows/starting-course.yml
+++ b/.github/workflows/starting-course.yml
@@ -3,9 +3,9 @@
 
 name: Starting a new course
 on:
-  # Trigger on page_build, as well as release created events
-  release:
-    types: [ created ]
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -13,7 +13,7 @@ jobs:
   template-cleanup:
     name: Template Cleanup
     runs-on: ubuntu-latest
-    if: ${{ github.event.repository.name != 'jhudsl/DaSL_Course_Template_Bookdown' }}
+    if: github.event.repository.name != 'DaSL_Course_Template_Bookdown'
     steps:
 
       # Check out current repository
@@ -45,6 +45,8 @@ jobs:
           title: New Course - Set Github Secrets
           content-filepath: .github/automatic-issues/git-secrets.md
           labels: automated training issue
+
+##### Delete Template-specific files that aren't needed for new courses
 
       # Cleanup Template-specific bits
       - name: Cleanup


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
Another attempt to make the trigger actually upon the use of this template. 

I realized the repository name does not include the org name so it needs just DaSL_Course_Template_Bookdown NOT jhudsl/DaSL_Course_Template_Bookdown. I think that may have been the problem let's see if the original way works otherwise when that is fixed. 

