### PR TITLE
Refactor author links to below on page (make `.md` table easier to read)

### DIFF
--- a/About.Rmd
+++ b/About.Rmd
@@ -28,7 +28,7 @@ These credits are based on our [course contributors table guidelines](https://gi
 |Template Publishing Engineers|[Candace Savonen], [Carrie Wright]|
 |Publishing Maintenance Engineer|[Candace Savonen]|
 |Technical Publishing Stylists|[Carrie Wright], [Candace Savonen]|
-|Package Developers ([Leanbuild]|[John Muschelli], [Candace Savonen], [Carrie Wright]|
+|Package Developers ([Leanbuild])|[John Muschelli], [Candace Savonen], [Carrie Wright]|
 |**Art and Design**||
 |Illustrator(s)| Created graphics for the course|
 |Figure Artist(s)| Created figures/plots for course|

--- a/About.Rmd
+++ b/About.Rmd
@@ -12,7 +12,7 @@ These credits are based on our [course contributors table guidelines](https://gi
 |Credits|Names|
 |-------|-----|
 |**Pedagogy**||
-|Lead Content Instructor(s)|[FirstName LastName](link to personal website)|
+|Lead Content Instructor(s)|[FirstName LastName]|
 |Lecturer(s) (include chapter name/link in parentheses if only for specific chapters) - make new line if more than one chapter involved| Delivered the course in some way - video or audio|
 |Content Author(s) (include chapter name/link in parentheses if only for specific chapters) - make new line if more than one chapter involved | If any other authors besides lead instructor| 
 |Content Contributor(s) (include section name/link in parentheses) - make new line if more than one section involved|  Wrote less than a chapter|
@@ -25,10 +25,10 @@ These credits are based on our [course contributors table guidelines](https://gi
 |Content Publishing Reviewer(s)| Reviewed overall content and aesthetics on publishing platform|
 |**Technical**||
 |Course Publishing Engineer(s)| Helped with the code for the technical aspects related to the specific course generation|
-|Template Publishing Engineers|[Candace Savonen](https://www.cansavvy.com/), [Carrie Wright](https://carriewright11.github.io/)|
-|Publishing Maintenance Engineer|[Candace Savonen](https://www.cansavvy.com/)|
-|Technical Publishing Stylists|[Carrie Wright](https://carriewright11.github.io/), [Candace Savonen](https://www.cansavvy.com/)|
-|Package Developers ([Leanbuild](https://github.com/jhudsl/leanbuild))|[John Muschelli](https://johnmuschelli.com/), [Candace Savonen](https://www.cansavvy.com/), [Carrie Wright](https://carriewright11.github.io/)|
+|Template Publishing Engineers|[Candace Savonen], [Carrie Wright]|
+|Publishing Maintenance Engineer|[Candace Savonen]|
+|Technical Publishing Stylists|[Carrie Wright], [Candace Savonen]|
+|Package Developers ([Leanbuild]|[John Muschelli], [Candace Savonen], [Carrie Wright]|
 |**Art and Design**||
 |Illustrator(s)| Created graphics for the course|
 |Figure Artist(s)| Created figures/plots for course|
@@ -46,10 +46,22 @@ These credits are based on our [course contributors table guidelines](https://gi
 devtools::session_info()
 ```
 
+<!-- Author information -->
+
+[FirstName LastName]: link to personal website
+[John Muschelli]: https://johnmuschelli.com/
+[Candace Savonen]: https://www.cansavvy.com/
+[Carrie Wright]: https://carriewright11.github.io/
+
+<!-- Links -->
+
+[Leanbuild]: https://github.com/jhudsl/leanbuild
+
 <!-- Fill out this table using these instructions: https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/How-to-give-credits
 
 For JHU courses, You will need to add Ira as a credit:
 
-|Content Publisher|[Ira Gooding](https://publichealth.jhu.edu/faculty/4130/ira-gooding)|
-
+|Content Publisher|[Ira Gooding]|
+...
+[Ira Gooding]: https://publichealth.jhu.edu/faculty/4130/ira-gooding
 -->


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

Hey @cansavvy  - this is a take it or leave it, but markdown tables personally hurt my brain and I wonder if something like this will make it easier to read. It has the added benefit of cutting down on repeated text.

### Purpose/implementation Section

This PR refactors author links embedded in the credits table to links below the table. Makes things cleaner IMO 🙂

#### What changes are being implemented in this Pull Request?

Refactoring, no content change

#### What was your approach?

Replacing links only, no content change

#### What GitHub issue does your pull request address?

None; feature

### Tell potential reviewers what kind of feedback you are soliciting.

Is this something that will help people? Open to ideas for why this is do-not-want!

### New Content Checklist

- [ ] New content/chapter is in an Rmd file with [this kind of format and headers](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/blob/main/02-chapter_of_course.Rmd).

- [ ] New content/chapter contains [Learning Objectives and are in the correct format](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/Setting-up-images-and-graphics#learning-objectives-formatting).

- [ ] [Bookdown successfully re-renders and any new content files have been added to the _bookdown.yml](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/Publishing-with-Bookdown).

- [ ] Spell check runs successfully in [Github actions style-n-check](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/How-to-set-up-and-customize-GitHub-actions-robots#spell-check)).

- [ ] Any newly necessary packages that are needed have been added to the [Dockerfile and image](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/Using-Docker#adding-packages-to-the-dockerfile).

- [ ] Images are in the [correct format for rendering](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/Setting-up-images-and-graphics#adding-images-and-graphics-in-text).

- [ ] Every new image has [alt text and is in a Google Slide](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/Setting-up-images-and-graphics#accessibility).

- [ ] Each slide is described in the notes of the slide so learners relying on a screen reader can access the content. See https://lastcallmedia.com/blog/accessible-comics for more guidance on this.

- [ ] The color palette choices of the slide are contrasted in a way that is friendly to those with color vision deficiencies.
You can check this using [Color Oracle](https://colororacle.org/).
